### PR TITLE
Feat: Implement duplicate login detection and log events into the database.

### DIFF
--- a/translate/index.ts
+++ b/translate/index.ts
@@ -14,6 +14,7 @@ setBulk({
         'auth.span.new.user': 'New User?',
         'auth.span.existing.user': 'Existing User?',
         'auth.kick.sessionKey': 'Not allowed to authenticate',
+        'auth.kick.alreadyLoggedIn': 'Already logged in',
     },
     hu: {
         'auth.span.login': 'Bejelentkezés',
@@ -27,6 +28,7 @@ setBulk({
         'auth.span.new.user': 'Új felhasználó?',
         'auth.span.existing.user': 'Van már fiókod?',
         'auth.kick.sessionKey': 'Not allowed to authenticate',
+        'auth.kick.alreadyLoggedIn': 'Already logged in',
     },
     ro: {
         'auth.span.login': 'Autentificare',
@@ -40,5 +42,6 @@ setBulk({
         'auth.span.new.user': 'Crează un cont.',
         'auth.span.existing.user': 'Am deja cont.',
         'auth.kick.sessionKey': 'Autentificarea nu este permisă.',
+        'auth.kick.alreadyLoggedIn': 'Ești deja autentificat.',
     },
 });

--- a/webview/AuthRegister.vue
+++ b/webview/AuthRegister.vue
@@ -53,7 +53,7 @@ function handleInvalid() {
 }
 
 function init() {
-    events.on(AuthEvents.fromServer.invalidLogin, handleInvalid);
+    events.on(AuthEvents.fromServer.invalidRegister, handleInvalid);
 }
 
 onMounted(init);


### PR DESCRIPTION
Description:
- Enhanced the login process to check for duplicate logins. If the account is already logged in, the player attempting to log in again with that account will be kicked, and this event will be recorded in the database with the targeted account ID, player IP, and timestamp.
- Added translations for the kick message.
- Fixed event call in the registration form to display the error when attempting to register an account with an email address that is already in use.
