### PR TITLE
Patch

### DIFF
--- a/webview/components/AuthLogin.vue
+++ b/webview/components/AuthLogin.vue
@@ -8,7 +8,7 @@ const { t } = useTranslate('en');
 
 const events = useEvents();
 
-const rememberMe = ref(true);
+const rememberMe = ref(false);
 const allValid = ref(false);
 const isInvalid = ref(false);
 
@@ -85,3 +85,12 @@ onMounted(init);
         </button>
     </div>
 </template>
+
+<style scoped>
+* {
+    font-family: "Inter", sans-serif;
+    font-optical-sizing: auto;
+    font-variation-settings: "slnt" 0;
+    user-select: none;
+}
+</style>

--- a/webview/components/AuthRegister.vue
+++ b/webview/components/AuthRegister.vue
@@ -96,3 +96,12 @@ onMounted(init);
         </button>
     </div>
 </template>
+
+<style scoped>
+* {
+    font-family: "Inter", sans-serif;
+    font-optical-sizing: auto;
+    font-variation-settings: "slnt" 0;
+    user-select: none;
+}
+</style>


### PR DESCRIPTION
Disabled user-select in css. // disable text selection on the page.
Set default font to Inter. // we can also use Inter font since altv loads it by default?
Opt-out default rememberMe ref. // should be false, if true it will be login-in via token anyhow